### PR TITLE
php7 已经不允许以同名方法来代替构造函数了，统一用—使用 __construct()‘

### DIFF
--- a/web/lib/geshi/geshi.php
+++ b/web/lib/geshi/geshi.php
@@ -588,7 +588,7 @@ class GeSHi {
      *               {@link GeSHi->set_language_path()}
      * @since 1.0.0
      */
-    function GeSHi($source = '', $language = '', $path = '') {
+    function __construct($source = '', $language = '', $path = '') {
         if (!empty($source)) {
             $this->set_source($source);
         }

--- a/web/lib/markdown_extra/markdown.php
+++ b/web/lib/markdown_extra/markdown.php
@@ -239,7 +239,7 @@ class Markdown_Parser {
 	var $predef_titles = array();
 
 
-	function Markdown_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize appropriate member variables.
 	#
@@ -1669,7 +1669,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	var $predef_abbr = array();
 
 
-	function MarkdownExtra_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize the parser object.
 	#
@@ -1695,7 +1695,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			"doAbbreviations"    => 70,
 			);
 		
-		parent::Markdown_Parser();
+		parent::__construct();
 	}
 	
 	


### PR DESCRIPTION
兼容更多的版本环境，便于开发者参与